### PR TITLE
Implement batch decoding for transformer models in Espnet2

### DIFF
--- a/egs/libritts/tts1/run.sh
+++ b/egs/libritts/tts1/run.sh
@@ -38,7 +38,8 @@ griffin_lim_iters=64  # the number of iterations of Griffin-Lim
 # Set this to somewhere where you want to put your data, or where
 # someone else has already put it. You'll want to change this
 # if you're not on the CLSP grid.
-datadir=/export/a15/vpanayotov/data
+#datadir=/export/a15/vpanayotov/data
+datadir=data_dwl
 
 # base url for downloads.
 data_url=www.openslr.org/resources/60
@@ -61,16 +62,20 @@ eval_set=test_clean
 if [ ${stage} -le -1 ] && [ ${stop_stage} -ge -1 ]; then
     echo "stage -1: Data Download"
     mkdir -p ${datadir}
-    for part in dev-clean test-clean train-clean-100 train-clean-360; do
+    #for part in dev-clean test-clean train-clean-100 train-clean-360; do
+    for part in dev-clean test-clean; do
         local/download_and_untar.sh ${datadir} ${data_url} ${part}
     done
 fi
+
+exit
 
 if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
     ### Task dependent. You have to make data the following preparation part by yourself.
     ### But you can utilize Kaldi recipes in most cases
     echo "stage 0: Data preparation"
-    for part in dev-clean test-clean train-clean-100 train-clean-360; do
+    #for part in dev-clean test-clean train-clean-100 train-clean-360; do
+    for part in dev-clean test-clean; do
         # use underscore-separated names in data directories.
         local/data_prep.sh ${datadir}/LibriTTS/${part} data/${part//-/_}
     done

--- a/egs2/TEMPLATE/asr1/path.sh
+++ b/egs2/TEMPLATE/asr1/path.sh
@@ -7,7 +7,7 @@ export PATH=$PWD/utils/:$KALDI_ROOT/tools/openfst/bin:$PATH
 export LC_ALL=C
 
 . "${MAIN_ROOT}"/tools/activate_python.sh && . "${MAIN_ROOT}"/tools/extra_path.sh
-export PATH=$MAIN_ROOT/utils:$MAIN_ROOT/espnet/bin:$PATH
+export PATH=$MAIN_ROOT/utils:$MAIN_ROOT/espnet/bin:$MAIN_ROOT/espnet2/bin:$PATH
 
 export OMP_NUM_THREADS=1
 

--- a/espnet/asr/pytorch_backend/recog.py
+++ b/espnet/asr/pytorch_backend/recog.py
@@ -33,7 +33,7 @@ def recog_v2(args):
     logging.warning("experimental API for custom LMs is selected by --api v2")
     if args.batchsize > 1:
         #raise NotImplementedError("multi-utt batch decoding is not implemented")
-        print("Mutli-utt batch decoding turned on")
+        print("Multi-utt batch decoding turned on")
     if args.streaming_mode is not None:
         raise NotImplementedError("streaming mode is not implemented")
     if args.word_rnnlm:
@@ -132,6 +132,8 @@ def recog_v2(args):
         for idx, name in enumerate(js.keys(), 1):
             logging.info("(%d/%d) decoding " + name, idx, len(js.keys()))
             batch = [(name, js[name])]
+            print('\nBATCH')
+            print(batch)
             feat = load_inputs_and_targets(batch)[0][0]
             enc = model.encode(torch.as_tensor(feat).to(device=device, dtype=dtype))
             nbest_hyps = beam_search(

--- a/espnet/asr/pytorch_backend/recog.py
+++ b/espnet/asr/pytorch_backend/recog.py
@@ -32,7 +32,8 @@ def recog_v2(args):
     """
     logging.warning("experimental API for custom LMs is selected by --api v2")
     if args.batchsize > 1:
-        raise NotImplementedError("multi-utt batch decoding is not implemented")
+        #raise NotImplementedError("multi-utt batch decoding is not implemented")
+        print("Mutli-utt batch decoding turned on")
     if args.streaming_mode is not None:
         raise NotImplementedError("streaming mode is not implemented")
     if args.word_rnnlm:

--- a/espnet/asr/pytorch_backend/recog.py
+++ b/espnet/asr/pytorch_backend/recog.py
@@ -18,6 +18,7 @@ from espnet.nets.scorers.length_bonus import LengthBonus
 from espnet.utils.deterministic_utils import set_deterministic_pytorch
 from espnet.utils.io_utils import LoadInputsAndTargets
 
+#Ds 
 
 def recog_v2(args):
     """Decode with custom models that implements ScorerInterface.

--- a/espnet/asr/pytorch_backend/recog.py
+++ b/espnet/asr/pytorch_backend/recog.py
@@ -18,8 +18,6 @@ from espnet.nets.scorers.length_bonus import LengthBonus
 from espnet.utils.deterministic_utils import set_deterministic_pytorch
 from espnet.utils.io_utils import LoadInputsAndTargets
 
-#Ds 
-
 def recog_v2(args):
     """Decode with custom models that implements ScorerInterface.
 

--- a/espnet/nets/pytorch_backend/e2e_asr_transformer.py
+++ b/espnet/nets/pytorch_backend/e2e_asr_transformer.py
@@ -424,7 +424,7 @@ class E2E(ASRInterface, torch.nn.Module):
         :rtype: torch.Tensor
         """
         self.eval()
-        print(x)
+        #print(x)
         x = torch.as_tensor(x)
         print('\nX')
         print(x)
@@ -433,21 +433,21 @@ class E2E(ASRInterface, torch.nn.Module):
         #print('\nX unsqueezed')
         #print(x)
         #print(x.size())
-        enc_outputs = []
-        for feat_seq in x:
-            print(feat_seq, feat_seq.size())
-            print(feat_seq.unsqueeze(0), feat_seq.unsqueeze(0).size())
-            enc_output, _ = self.encoder(feat_seq.unsqueeze(0), None)
-            enc_outputs.append(enc_output.squeeze(0))
-        #enc_output, _ = self.encoder(x, None)
-        output = torch.stack(enc_outputs)
-        print('OUTPUT', output.size())
+        #enc_outputs = []
+        #for feat_seq in x:
+        #    print(feat_seq, feat_seq.size())
+        #    print(feat_seq.unsqueeze(0), feat_seq.unsqueeze(0).size())
+        #    enc_output, _ = self.encoder(feat_seq.unsqueeze(0), None)
+        #    enc_outputs.append(enc_output.squeeze(0))
+        enc_output, _ = self.encoder(x, None)
+        #output = torch.stack(enc_outputs)
+        #print('OUTPUT', output.size())
         #print('\nX ENCODED')
         #print(enc_output, enc_output.size())
         #print('\nX ENCODED squeezed')
         #print(enc_output.squeeze(0), enc_output.squeeze(0).size())
-        #return enc_output.squeeze(0)
-        return output
+        return enc_output.squeeze(0)
+        #return output
 
     def recognize(self, x, recog_args, char_list=None, rnnlm=None, use_jit=False):
         """Recognize input speech.
@@ -459,6 +459,8 @@ class E2E(ASRInterface, torch.nn.Module):
         :return: N-best decoding results
         :rtype: list
         """
+        print('RECOGNIZE')
+        print(x, type(x), x.shape)
         enc_output = self.encode(x).unsqueeze(0)
         if self.mtlalpha == 1.0:
             recog_args.ctc_weight = 1.0
@@ -669,7 +671,7 @@ class E2E(ASRInterface, torch.nn.Module):
         )
         return nbest_hyps
 
-    def recognize_batch(self, xs, recog_args, char_list, beam_search, rnnlm=None):
+    def recognize_batch(self, xs, recog_args, char_list, rnnlm=None):
         """E2E batch beam search.
         
         :param list xs: list of input acoustic feature arrays [(T_1, D), (T_2, D), ...]
@@ -680,24 +682,26 @@ class E2E(ASRInterface, torch.nn.Module):
         :rtype: list
         """
         
-        if recog_args.ngpu == 1:
-            device = "cuda"
-        else:
-            device = "cpu"
+        #if recog_args.ngpu == 1:
+        #    device = "cuda"
+        #else:
+        #    device = "cpu"
 
         prev = self.training
         self.eval()
         ilens = numpy.fromiter((xx.shape[0] for xx in xs), dtype=numpy.int64)
+        print('\nILENS')
         print(len(ilens), ilens.shape)
+        print(ilens)
         
         # subsample frame
         xs = [xx[:: self.subsample[0], :] for xx in xs]
         xs = [to_device(self, to_torch_tensor(xx).float()) for xx in xs]
         print('\nXS\n')
-        #print(len(xs), len(xs[1]))
+        print(len(xs), len(xs[0]))
         xs_pad = pad_list(xs, 0.0)
         print('\nXS_PAD\n')
-        #print(len(xs_pad), len(xs_pad[1]))
+        print(len(xs_pad), len(xs_pad[0]))
 
         # 0. Frontend
         #if self.frontend is not None:
@@ -707,7 +711,7 @@ class E2E(ASRInterface, torch.nn.Module):
         #    hs_pad, hlens = xs_pad, ilens
         hs_pad, hlens = xs_pad, ilens
         print('HS_PAD')
-        print(hs_pad)
+        print(hs_pad, hs_pad.size())
         print('HLENS')
         print(hlens)
 
@@ -715,7 +719,8 @@ class E2E(ASRInterface, torch.nn.Module):
         #hs_pad, hlens, _ = self.enc(hs_pad, hlens)
         dtype = getattr(torch, recog_args.dtype)
         #dtype = torch.float32
-        hs_pad = self.encode(torch.as_tensor(hs_pad).to(device=device,dtype=dtype))
+        hs_pad = self.encode(torch.as_tensor(hs_pad))
+        #hs_pad = self.encode(torch.as_tensor(hs_pad).to(device=device,dtype=dtype))
         print('ENNNNNNC')
         print(hs_pad, hs_pad.size())
 
@@ -730,18 +735,18 @@ class E2E(ASRInterface, torch.nn.Module):
         #    ]
         #    batch_nbest_hyps.append(nbest_hyps)
         # calculate log P(z_t|X) for CTC scores
-        if recog_args.ctc_weight > 0.0:
-            lpz = self.ctc.log_softmax(hs_pad)
-            normalize_score = False
-        else:
-            lpz = None
-            normalize_score = True
+        #if recog_args.ctc_weight > 0.0:
+        #    lpz = self.ctc.log_softmax(hs_pad)
+        #    normalize_score = False
+        #else:
+        #    lpz = None
+        #    normalize_score = True
 
-        #lpz = None
-        #normalize_score = True
+        lpz = None
+        normalize_score = True
 
         hlens = torch.tensor(list(map(int,hlens))) # make sure hlens is tensor
-        y = self.recognize_beam_batch(
+        y = self.decoder.recognize_beam_batch(
             hs_pad,
             hlens,
             lpz,

--- a/espnet/nets/pytorch_backend/rnn/decoders.py
+++ b/espnet/nets/pytorch_backend/rnn/decoders.py
@@ -713,7 +713,19 @@ class Decoder(torch.nn.Module, ScorerInterface):
         if self.num_encs == 1:
             a_prev = [None]
             att_w_list, ctc_scorer, ctc_state = [None], [None], [None]
+            print('BEFORE RESET')
+            print(self.att)
+            print(att_idx)
+            print(self.att[att_idx])
+            print(self.att[att_idx].h_length)
+            print(self.att[att_idx].enc_h)
+            print(self.att[att_idx].pre_compute_enc_h)
+            print(self.att[att_idx].mask)
             self.att[att_idx].reset()  # reset pre-computation of h
+            print('RESET')
+            print(self.att)
+            print(att_idx)
+            print(self.att[att_idx])
         else:
             a_prev = [None] * (self.num_encs + 1)  # atts + han
             att_w_list = [None] * (self.num_encs + 1)  # atts + han

--- a/espnet/nets/pytorch_backend/rnn/decoders.py
+++ b/espnet/nets/pytorch_backend/rnn/decoders.py
@@ -650,6 +650,8 @@ class Decoder(torch.nn.Module, ScorerInterface):
         if self.num_encs > 1 and lpz is None:
             lpz = [lpz] * self.num_encs
 
+        print('ATT')
+        print(self.att, len(self.att))
         att_idx = min(strm_idx, len(self.att) - 1)
         for idx in range(self.num_encs):
             logging.info(

--- a/espnet/nets/pytorch_backend/transformer/decoder.py
+++ b/espnet/nets/pytorch_backend/transformer/decoder.py
@@ -129,8 +129,8 @@ class Decoder(BatchScorerInterface, torch.nn.Module):
                     concat_after,
                 ),
             )
-            print('DECODERS', type(self.decoders[0])
-            print(self.decoders[0].feed_forward)
+            print('DECODERS', type(self.decoders))
+            print(self.decoders[0])
         elif selfattention_layer_type == "lightconv":
             logging.info("decoder self-attention layer type = lightweight convolution")
             self.decoders = repeat(
@@ -440,7 +440,7 @@ class Decoder(BatchScorerInterface, torch.nn.Module):
         if num_encs == 1:
             a_prev = [None]
             att_w_list, ctc_scorer, ctc_state = [None], [None], [None]
-            self.att[att_idx].reset()  # reset pre-computation of h
+            #self.att[att_idx].reset()  # reset pre-computation of h
         else:
             a_prev = [None] * (num_encs + 1)  # atts + han
             att_w_list = [None] * (num_encs + 1)  # atts + han


### PR DESCRIPTION
Experiments run on 184

- Change directory to espnet/egs2/ubiqus-us/asr2

- Two options to run inference on a test audio file:

1. With pre trained model trained on Librispeech (1k hours) downloaded from https://github.com/espnet/espnet_model_zoo. This model takes raw audio as input, which is not the way I trained our Ubiqus model.
In order to transcribe a long audio file, we split it into utterances using a Speech Activity Detection model, create corresponding shorter audio files and sequentially process them through the model.
Command to replicate the error (whatever batch size > 1): `./local/recog_wav_utts_raw.sh --nj 4 --ngpu 1 --batch_size 2 rev/5.wav`

2. With Ubiqus model trained on our internal data (around 10k hours). This model takes audio features (MFCC) as input.
To transcribe an audio file, we do it the same way as for 1. but instead of creating utterance-level audio files, we compute MFCC sequences for each utterance.
Command to replicate the error (whatever batch size > 1): `./local/recog_wav_utts_feats.sh rev/5.wav`

Ouput directories are created in the `decode` folder. Both models have the same architecture described in `conf/tuning/train_asr_transformer3.yaml`. Although the two models don't handle inputs the same way, this should not impact the batch beam search process and we can work on the pre trained model, so that we're able to ask for help if needed.